### PR TITLE
Add correct repoName in build fail notification

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -33,6 +33,6 @@ jobs:
                 --data "{
                   \"event_type\": \"notify-build-failure\",
                   \"client_payload\": {
-                    \"repoName\": \"module-ballerinax-aws.sqs\"
+                    \"repoName\": \"module-ballerinax-aws.dynamodb\"
                   }
                 }"


### PR DESCRIPTION
## Purpose
- Add correct repoName in build fail notification
